### PR TITLE
Send video chunks over the msg channel

### DIFF
--- a/main.go
+++ b/main.go
@@ -81,7 +81,8 @@ ConsumerLoop:
 			if err != nil {
 				zap.S().Fatalf("msgUnmarshalled error %s", err)
 			}
-			zap.S().Debugf("Consumed message payload %s", msgUnmarshalled)
+
+			msgChan <- msgUnmarshalled
 
 			consumed++
 		case <-signals:


### PR DESCRIPTION
**Problem**

The video chunks are not sent from the kafka consumer to the websocket server, within the video-stream-service.

**Solution**

Send received video chunks down the msgChan, to be propagated to the websocket clients.