### PR TITLE
Fix disconnect panic

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
       mediaSource.addEventListener(
         "sourceopen",
         function (e) {
-          // video.play();
+          video.play();
 
           buffer = mediaSource.addSourceBuffer(mimeCodec);
 

--- a/index.html
+++ b/index.html
@@ -1,58 +1,84 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
+  <head>
+    <meta charset="UTF-8" />
     <title>MSE Demo</title>
-</head>
-<body>
-<h1>MSE Demo</h1>
-<div>
-    <video controls width="80%"></video>
-</div>
-<script type="text/javascript">
-    const websocket = new WebSocket('ws://localhost:9999/ws');
-    websocket.binaryType = 'arraybuffer';
+  </head>
+  <body>
+    <h1>MSE Demo</h1>
+    <div>
+      <video controls width="80%"></video>
+    </div>
+    <script type="text/javascript">
+      const websocket = new WebSocket("ws://localhost:9999/ws");
+      websocket.binaryType = "arraybuffer";
 
-    const mediaSource = new MediaSource();
-    const mimeCodec = 'video/mp4; codecs="avc1.64001e, mp4a.40.2"'
-    let buffer;
-    const queue = [];
+      const mediaSource = new MediaSource();
+      const mimeCodec = 'video/mp4; codecs="avc1.64001e, mp4a.40.2"';
+      let buffer;
+      const queue = [];
 
-    const video = document.querySelector('video');
-    video.src = window.URL.createObjectURL(mediaSource);
+      const video = document.querySelector("video");
+      video.src = window.URL.createObjectURL(mediaSource);
 
-    mediaSource.addEventListener('sourceopen', function(e) {
-        video.play();
+      mediaSource.addEventListener(
+        "sourceopen",
+        function (e) {
+          // video.play();
 
-        buffer = mediaSource.addSourceBuffer(mimeCodec);
+          buffer = mediaSource.addSourceBuffer(mimeCodec);
 
-        buffer.addEventListener('updatestart', function(e) { console.log('updatestart: ' + mediaSource.readyState); });
-        buffer.addEventListener('update', function(e) { console.log('update: ' + mediaSource.readyState); });
-        buffer.addEventListener('updateend', function(e) { console.log('updateend: ' + mediaSource.readyState); });
-        buffer.addEventListener('error', function(e) { console.log('error: ' + mediaSource.readyState); });
-        buffer.addEventListener('abort', function(e) { console.log('abort: ' + mediaSource.readyState); });
+          buffer.addEventListener("updatestart", function (e) {
+            console.log("updatestart: " + mediaSource.readyState);
+          });
+          buffer.addEventListener("update", function (e) {
+            console.log("update: " + mediaSource.readyState);
+          });
+          buffer.addEventListener("updateend", function (e) {
+            console.log("updateend: " + mediaSource.readyState);
+          });
+          buffer.addEventListener("error", function (e) {
+            console.log("error: " + mediaSource.readyState);
+          });
+          buffer.addEventListener("abort", function (e) {
+            console.log("abort: " + mediaSource.readyState);
+          });
 
-        buffer.addEventListener('update', function() {
+          buffer.addEventListener("update", function () {
             if (queue.length > 0 && !buffer.updating) {
-                buffer.appendBuffer(queue.shift());
+              buffer.appendBuffer(queue.shift());
             }
-        });
-    }, false);
+          });
+        },
+        false
+      );
 
-    mediaSource.addEventListener('sourceopen', function(e) { console.log('sourceopen: ' + mediaSource.readyState); });
-    mediaSource.addEventListener('sourceended', function(e) { console.log('sourceended: ' + mediaSource.readyState); });
-    mediaSource.addEventListener('sourceclose', function(e) { console.log('sourceclose: ' + mediaSource.readyState); });
-    mediaSource.addEventListener('error', function(e) { console.log('error: ' + mediaSource.readyState); });
+      mediaSource.addEventListener("sourceopen", function (e) {
+        console.log("sourceopen: " + mediaSource.readyState);
+      });
+      mediaSource.addEventListener("sourceended", function (e) {
+        console.log("sourceended: " + mediaSource.readyState);
+      });
+      mediaSource.addEventListener("sourceclose", function (e) {
+        console.log("sourceclose: " + mediaSource.readyState);
+      });
+      mediaSource.addEventListener("error", function (e) {
+        console.log("error: " + mediaSource.readyState);
+      });
 
-    websocket.addEventListener('message', function(e) {
-        if (typeof e.data !== 'string') {
+      websocket.addEventListener(
+        "message",
+        function (e) {
+          if (typeof e.data !== "string") {
             if (buffer.updating || queue.length > 0) {
-                queue.push(e.data);
+              queue.push(e.data);
             } else {
-                buffer.appendBuffer(e.data);
+              buffer.appendBuffer(e.data);
             }
-        }
-    }, false);
-</script>
-</body>
+          }
+        },
+        false
+      );
+    </script>
+  </body>
 </html>

--- a/websocket/server.go
+++ b/websocket/server.go
@@ -94,8 +94,8 @@ func (c *Controller) HandleWs(w http.ResponseWriter, r *http.Request) {
 	c.clientLock.Lock()
 	c.clients[client.ID] = client
 	c.clientLock.Unlock()
-	zap.S().Info("client added: %s", client.ID)
-	zap.S().Debug("current clients: %#v", c.clients)
+	zap.S().Infof("client added: %s", client.ID)
+	zap.S().Debugf("current clients: %#v", c.clients)
 
 	// Allow collection of memory referenced by the caller by doing all work in
 	// new goroutines.

--- a/websocket/server.go
+++ b/websocket/server.go
@@ -94,6 +94,8 @@ func (c *Controller) HandleWs(w http.ResponseWriter, r *http.Request) {
 	c.clientLock.Lock()
 	c.clients[client.ID] = client
 	c.clientLock.Unlock()
+	zap.S().Info("client added: %s", client.ID)
+	zap.S().Debug("current clients: %#v", c.clients)
 
 	// Allow collection of memory referenced by the caller by doing all work in
 	// new goroutines.

--- a/websocket/server.go
+++ b/websocket/server.go
@@ -85,6 +85,8 @@ func (c *Controller) HandleWs(w http.ResponseWriter, r *http.Request) {
 		defer c.clientLock.Unlock()
 		delete(c.clients, client.ID)
 
+		zap.S().Infof("client %s disconnected")
+
 		return nil
 	})
 


### PR DESCRIPTION
Problem

When a client disconnects from the websocket server, the sever panics due to not removing the client from the internal client dictionary.

Solution

Set a close handler to remove the client